### PR TITLE
Support arrays and objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ const payload = tofd({
   last_name: 'hello',
   // Nested arrays and objects
   tags: [{ id: 1 } , { id: 2 }],
-  // Files and buffers
-  attachments: [File],
-  avatar: avatar
+  // Files and Buffers
+  attachments: [File, File],
+  avatar: File
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tofd
 
-Converts an object to a FormData representation. Also supports nested arrays, objects, File, and Buffers.
+Converts an object to a `FormData` representation. Also supports nested arrays, objects, `File`, and `Buffer`s.
 
 ## Installation
 ```bash
@@ -39,4 +39,4 @@ const payload = tofd({
 ```
 tofd(obj: Object): FormData
 ```
-Accepts an object that gets converted into FormData.
+Accepts an object that gets converted into `FormData`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ npm i tofd --save
 ```
 
 ## Why
-This allows you to declaratively create a `FormData` instead of having to `append` each property.
+This library allows you to declaratively create a `FormData` instead of having to `append` each property.
 
-### Before
 ```diff
 - const payload = new FormData()
 - payload.append('first_name', firstName)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tofd
 
-Converts an object to a FormData representation. Also supports nested arrays, objects, File and Buffers.
+Converts an object to a FormData representation. Also supports nested arrays, objects, File, and Buffers.
 
 ## Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # tofd
 
-Converts an object to a FormData representation
+Converts an object to a FormData representation. Also supports nested arrays, objects, File and Buffers.
+
+## Installation
+```bash
+npm i tofd --save
+```
+
+## Why
+This allows you to declaratively create a `FormData` instead of having to `append` each property.
+
+### Before
+```diff
+- const payload = new FormData()
+- payload.append('first_name', firstName)
+- payload.append('last_name', lastName)
++ const payload = tofd({
++   first_name: firstName,
++   last_name: lastName
++ })
+fetch('/user', { method: 'POST', body: payload })
+```
+
+## Usage
+```js
+const payload = tofd({
+  // Basic data types
+  first_name: 'hello',
+  last_name: 'hello',
+  // Nested arrays and objects
+  tags: [{ id: 1 } , { id: 2 }],
+  // Files and buffers
+  attachments: [File],
+  avatar: avatar
+})
+```
+
+## API
+```
+tofd(obj: Object): FormData
+```
+Accepts an object that gets converted into FormData.

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -6,7 +6,10 @@ const object = {
   b: 'some_random_b',
   users: [
     { name: 'john doe '}
-  ]
+  ],
+  hello: {
+    world: Buffer.from([1, 2, 3])
+  }
 };
 
 describe('tofd', () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -3,8 +3,10 @@ import tofd from '../index';
 
 const object = {
   a: 'some_random_a',
-  b: 'some_random_a',
-  c: undefined,
+  b: 'some_random_b',
+  users: [
+    { name: 'john doe '}
+  ]
 };
 
 describe('tofd', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function flattenKeys(obj) {
         ? `${parentKey}[${key}]`
         : key;
 
-      if ((typeof value === 'object' || Array.isArray(value)) && !(value instanceof File)) {
+      if ((typeof value === 'object' || Array.isArray(value)) &&
+        (!(value instanceof File) && !Buffer.isBuffer(value))) {
         flatten(value, newKey);
       } else {
         output[newKey] = value;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,35 @@
 import FormData from 'form-data';
 
-const tofd = obj => Object.keys(obj).reduce((fd, k) => {
-  if (obj[k]) fd.append(k, obj[k]);
-  return fd;
-}, new FormData());
+function tofd(obj) {
+  const flattened = flattenKeys(obj)
+
+  return Object.keys(flattened).reduce((fd, k) => {
+    fd.append(k, flattened[k])
+  }, new FormData());
+}
+
+function flattenKeys(obj) {
+  let output = {}
+  
+  function flatten(obj, parentKey) {
+    Object.keys(obj).forEach(key => {
+      const value = obj[key]
+
+      const newKey = parentKey
+        ? `${parentKey}[${key}]`
+        : key
+  
+      if ((typeof value === 'object' || Array.isArray(value)) && !(value instanceof File)) {
+        flatten(value, newKey)
+      } else {
+        output[newKey] = value
+      }
+    })
+  }
+
+  flatten(obj)
+  
+  return output
+}
 
 module.exports = tofd;

--- a/src/index.js
+++ b/src/index.js
@@ -1,35 +1,36 @@
 import FormData from 'form-data';
 
 function tofd(obj) {
-  const flattened = flattenKeys(obj)
+  const flattened = flattenKeys(obj);
 
   return Object.keys(flattened).reduce((fd, k) => {
-    fd.append(k, flattened[k])
+    fd.append(k, flattened[k]);
+    return fd;
   }, new FormData());
 }
 
 function flattenKeys(obj) {
   let output = {}
-  
+
   function flatten(obj, parentKey) {
     Object.keys(obj).forEach(key => {
-      const value = obj[key]
+      const value = obj[key];
 
       const newKey = parentKey
         ? `${parentKey}[${key}]`
-        : key
-  
+        : key;
+
       if ((typeof value === 'object' || Array.isArray(value)) && !(value instanceof File)) {
-        flatten(value, newKey)
+        flatten(value, newKey);
       } else {
-        output[newKey] = value
+        output[newKey] = value;
       }
     })
   }
 
-  flatten(obj)
-  
-  return output
+  flatten(obj);
+
+  return output;
 }
 
 module.exports = tofd;


### PR DESCRIPTION
Currently, this is tofd works:

```js
fd.append('users', [{ name: 'hello' }])
```

This PR adds array and object support. For arrays and objects to work with FormData, you have to set it like so:

```js
fd.append('users[0][name]', 'hello')
```

I haven't added any tests yet. In addition, it adds significant weight to the package.